### PR TITLE
Updated queueit exception handling happ-511

### DIFF
--- a/app/src/main/java/ca/bc/gov/bchealth/MainViewModel.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/MainViewModel.kt
@@ -1,0 +1,24 @@
+package ca.bc.gov.bchealth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ca.bc.gov.repository.QueueItTokenRepository
+import ca.bc.gov.repository.bcsc.BcscAuthRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/*
+* Created by amit_metri on 28,May,2022
+*/
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val queueItTokenRepository: QueueItTokenRepository,
+    private val bcscAuthRepo: BcscAuthRepo
+) : ViewModel() {
+
+    fun setQueItToken(token: String?) = viewModelScope.launch {
+        queueItTokenRepository.setQueItToken(token)
+        bcscAuthRepo.executeOneTimeDatFetch()
+    }
+}

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthpass/add/FetchVaccineRecordFragment.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthpass/add/FetchVaccineRecordFragment.kt
@@ -362,7 +362,7 @@ class FetchVaccineRecordFragment : BaseFragment(R.layout.fragment_fetch_vaccine_
             )
             queueITEngine.run(requireActivity())
         } catch (e: Exception) {
-            e.printStackTrace()
+            // no implementation required
         }
     }
 }

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/login/BcscAuthFragment.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/login/BcscAuthFragment.kt
@@ -166,12 +166,13 @@ class BcscAuthFragment : Fragment(R.layout.fragment_bcsc_auth) {
 
     private fun handleQueueIt(authStatus: AuthStatus) {
         if (authStatus.onMustBeQueued && authStatus.queItUrl != null) {
+            viewModel.resetAuthStatus()
             queUser(authStatus.queItUrl)
         }
 
         if (authStatus.queItTokenUpdated) {
             viewModel.resetAuthStatus()
-            viewModel.verifyLoad()
+            viewModel.checkAgeLimit() // Queueit exception is thrown for age limit check API
         }
     }
 

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/login/BcscAuthViewModel.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/login/BcscAuthViewModel.kt
@@ -224,7 +224,8 @@ class BcscAuthViewModel @Inject constructor(
                 ageLimitCheck = null,
                 canInitiateBcscLogin = null,
                 onMustBeQueued = false,
-                tosAccepted = null
+                tosAccepted = null,
+                queItUrl = null
             )
         }
     }

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/newsfeed/NewsfeedViewModel.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/newsfeed/NewsfeedViewModel.kt
@@ -59,7 +59,7 @@ class NewsfeedViewModel @Inject constructor() : ViewModel() {
 
             newsfeedMutableLiveData.postValue(newsFeeds)
         } catch (e: Exception) {
-            e.printStackTrace()
+            // no implementation required
         }
     }
 

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/onboarding/CameraPermissionFragment.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/onboarding/CameraPermissionFragment.kt
@@ -106,7 +106,7 @@ class CameraPermissionFragment : Fragment(R.layout.fragment_camera_permission) {
                     intent.data = uri
                     startActivity(intent)
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    // no implementation required
                 }
             }
         )

--- a/app/src/main/java/ca/bc/gov/bchealth/utils/Extensions.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/utils/Extensions.kt
@@ -21,31 +21,15 @@ import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.graphics.drawable.toBitmap
 import ca.bc.gov.bchealth.R
-import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
-import java.util.Locale
 
 /*
 * For displaying Toast
 * */
 fun Context.toast(message: String) =
     Toast.makeText(this, message, Toast.LENGTH_LONG).show()
-
-/*
-* For date to be shown under every news feed
-* */
-fun Long.getNewsFeedDate(): String {
-    return try {
-        val date = Date(this)
-        val format = SimpleDateFormat("y-MM-d", Locale.CANADA)
-        format.format(date)
-    } catch (e: java.lang.Exception) {
-        e.printStackTrace()
-        ""
-    }
-}
 
 /*
 * Check is network connection
@@ -94,7 +78,6 @@ fun Context.redirect(url: String) {
             Uri.parse(url)
         )
     } catch (e: Exception) {
-        e.printStackTrace()
         showURLFallBack(this, url)
     }
 }

--- a/data/src/main/java/ca/bc/gov/data/utils/Extensions.kt
+++ b/data/src/main/java/ca/bc/gov/data/utils/Extensions.kt
@@ -20,7 +20,6 @@ suspend inline fun <T> safeCall(crossinline responseFun: suspend () -> Response<
             )
         }
     } catch (e: Exception) {
-        e.printStackTrace()
         when (e) {
             is ProtectiveWordException -> {
                 throw e

--- a/repository/src/main/java/ca/bc/gov/repository/QrCodeGeneratorRepository.kt
+++ b/repository/src/main/java/ca/bc/gov/repository/QrCodeGeneratorRepository.kt
@@ -43,7 +43,6 @@ class QrCodeGeneratorRepository {
 
             return addWhiteBorder(scaledBitMap, 10)
         } catch (e: Exception) {
-            e.printStackTrace()
             return null
         }
     }

--- a/repository/src/main/java/ca/bc/gov/repository/di/DecoderModule.kt
+++ b/repository/src/main/java/ca/bc/gov/repository/di/DecoderModule.kt
@@ -57,7 +57,7 @@ class DecoderModule {
                 val jwks = Gson().fromJson(jwksKeysJson, Jwks::class.java)
                 defaultKeys.add(DefaultJWKSKeys(issuer.iss, jwks.keys))
             } catch (e: Exception) {
-                e.printStackTrace()
+                // no implementation required
             }
         }
         return defaultKeys.toList()


### PR DESCRIPTION
-updated queueit exception handling happ-511
Root cause:  During login /MobileConfiguration end point was configured to handle queueIt exception as it was the first call to HG and was expected to ask for QueueIt token. During actual testing /Validate API endpoint was asking for QueueIt token.

Code has been placed to handle QueueIt exception during background refresh.