### PR TITLE
Updated queueit token and cookie usage: HAPP-890

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "ca.bc.gov.myhealth"
         minSdk 27
         targetSdk 31
-        versionCode 14
+        versionCode 18
         versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -31,7 +31,7 @@ android {
 
     buildTypes {
         release {
-            debuggable false
+            debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/gradlew
+++ b/gradlew
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MINGW* )
+  MSYS* | MINGW* )
     msys=true
     ;;
   NONSTOP* )

--- a/repository/src/main/java/ca/bc/gov/repository/bcsc/BcscAuthRepo.kt
+++ b/repository/src/main/java/ca/bc/gov/repository/bcsc/BcscAuthRepo.kt
@@ -112,7 +112,7 @@ class BcscAuthRepo(
     /*
     * Check for logged in session
     * */
-    suspend fun checkSession(): Boolean {
+    fun checkSession(): Boolean {
         val authState = getAuthState() ?: return false
         return !authState.needsTokenRefresh
     }

--- a/repository/src/main/java/ca/bc/gov/repository/worker/FetchAuthenticatedHealthRecordsWorker.kt
+++ b/repository/src/main/java/ca/bc/gov/repository/worker/FetchAuthenticatedHealthRecordsWorker.kt
@@ -212,7 +212,7 @@ class FetchAuthenticatedHealthRecordsWorker @AssistedInject constructor(
      * Fetch lab test results
      * */
     private suspend fun fetchLabTestResults(authParameters: Pair<String, String>): List<LabOrderWithLabTestDto>? {
-        var labOrdersResponse: List<LabOrderWithLabTestDto>? = null
+        var labOrdersResponse: List<LabOrderWithLabTestDto>?
         withContext(dispatcher) {
             labOrdersResponse =
                 labOrderRepository.fetchLabOrders(
@@ -227,7 +227,7 @@ class FetchAuthenticatedHealthRecordsWorker @AssistedInject constructor(
     * Fetch medication records
     * */
     private suspend fun fetchMedicationResponse(authParameters: Pair<String, String>): MedicationStatementResponse? {
-        var medicationResponse: MedicationStatementResponse? = null
+        var medicationResponse: MedicationStatementResponse?
         withContext(dispatcher) {
             medicationResponse = medicationRecordRepository.fetchMedicationStatement(
                 authParameters.first,
@@ -242,7 +242,7 @@ class FetchAuthenticatedHealthRecordsWorker @AssistedInject constructor(
     * Fetch vaccine records
     * */
     private suspend fun fetchVaccineRecords(authParameters: Pair<String, String>): Pair<VaccineRecordState, PatientVaccineRecord?>? {
-        var vaccineRecordsResponse: Pair<VaccineRecordState, PatientVaccineRecord?>? = null
+        var vaccineRecordsResponse: Pair<VaccineRecordState, PatientVaccineRecord?>?
         withContext(dispatcher) {
             vaccineRecordsResponse = fetchVaccineRecordRepository.fetchVaccineRecord(
                 authParameters.first,
@@ -256,7 +256,7 @@ class FetchAuthenticatedHealthRecordsWorker @AssistedInject constructor(
     * Fetch covid test results
     * */
     private suspend fun fetchCovidTestResults(authParameters: Pair<String, String>): List<CovidOrderWithCovidTestDto>? {
-        var covidOrderResponse: List<CovidOrderWithCovidTestDto>? = null
+        var covidOrderResponse: List<CovidOrderWithCovidTestDto>?
         withContext(dispatcher) {
             covidOrderResponse = covidOrderRepository.fetchCovidOrders(
                 authParameters.first,


### PR DESCRIPTION
-updated queueit token and cookie usage: HAPP-890.
-queue token will be only passed to the network call which requires queueing. 
-subsequent network calls will be using the cookie received from above network call. 