### PR TITLE
Bugfix/search filter rewrite

### DIFF
--- a/app/src/main/java/ca/bc/gov/bchealth/MainActivity.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/MainActivity.kt
@@ -141,7 +141,7 @@ class MainActivity : AppCompatActivity() {
                             false
                         )
                         if (started) {
-                            binding.navHostFragment.showErrorSnackbar(getString(R.string.notification_title_while_fetching_data))
+                            binding.navHostFragment.showErrorSnackbar(getString(R.string.notification_title_while_fetching_data), binding.bottomNav)
                         }
                     }
 

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/component/AppliedFilterUI.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/component/AppliedFilterUI.kt
@@ -1,0 +1,54 @@
+package ca.bc.gov.bchealth.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ca.bc.gov.bchealth.R
+import ca.bc.gov.bchealth.compose.BasePreview
+import ca.bc.gov.bchealth.compose.MyHealthTheme
+
+@Composable
+fun AppliedFilterUI(
+    modifier: Modifier = Modifier,
+    filtersApplied: List<String>,
+    onFilterCleared: () -> Unit = {}
+) {
+    Row(modifier = modifier) {
+        IconButton(onClick = onFilterCleared) {
+            Icon(
+                painterResource(id = R.drawable.ic_clear),
+                contentDescription = stringResource(id = R.string.clear_all),
+                tint = MaterialTheme.colors.primary
+            )
+        }
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(1f),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(filtersApplied) {
+                HGFilterChip(text = it) {
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@BasePreview
+private fun AppliedFilterUIPreview() {
+    MyHealthTheme {
+        AppliedFilterUI(Modifier.fillMaxWidth(), emptyList())
+    }
+}

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/component/Chip.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/component/Chip.kt
@@ -1,0 +1,54 @@
+package ca.bc.gov.bchealth.ui.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material.ChipDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FilterChip
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import ca.bc.gov.bchealth.compose.BasePreview
+import ca.bc.gov.bchealth.compose.MyHealthTheme
+import ca.bc.gov.bchealth.compose.white
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun HGFilterChip(
+    text: String,
+    selected: Boolean = false,
+    onClick: () -> Unit
+) {
+
+    FilterChip(
+        selected = selected,
+        onClick = { onClick() },
+        shape = MaterialTheme.shapes.small.copy(CornerSize(8.dp)),
+        border = BorderStroke(
+            1.dp, MaterialTheme.colors.primary
+        ),
+        colors = ChipDefaults.outlinedFilterChipColors(
+            selectedContentColor = MaterialTheme.colors.background,
+            selectedBackgroundColor = MaterialTheme.colors.primary
+        )
+    ) {
+        Text(
+            text,
+            color = if (selected) {
+                white
+            } else {
+                MaterialTheme.colors.primary
+            },
+            style = MaterialTheme.typography.body1
+        )
+    }
+}
+
+@Composable
+@BasePreview
+private fun HGChipPreview() {
+    MyHealthTheme {
+        HGFilterChip("Hello world", selected = false, onClick = {})
+    }
+}

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/component/EmptyStateUI.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/component/EmptyStateUI.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +34,6 @@ fun EmptyStateUI(
 ) {
     Column(
         modifier
-            .padding(start = 32.dp, end = 32.dp)
             .fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/component/SearchBarUI.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/component/SearchBarUI.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
@@ -22,13 +21,16 @@ import ca.bc.gov.bchealth.compose.mediumGrey
 @Composable
 fun SearchBarUI(
     modifier: Modifier = Modifier,
+    enableFilter: Boolean = true,
     onFilterClicked: () -> Unit = {}
 ) {
     Row(
         modifier = modifier
-            .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-            .border(width = 1.dp, shape = MaterialTheme.shapes.medium, color = mediumGrey)
-            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                shape = MaterialTheme.shapes.medium,
+                color = mediumGrey
+            )
     ) {
         AndroidView(
             modifier = Modifier.weight(1f, fill = true),
@@ -42,14 +44,16 @@ fun SearchBarUI(
             }
         )
 
-        Image(
-            modifier = Modifier
-                .clickable { onFilterClicked() }
-                .size(width = 48.dp, height = 48.dp)
-                .padding(12.dp),
-            painter = painterResource(id = R.drawable.ic_filter),
-            contentDescription = "Filter"
-        )
+        if (enableFilter) {
+            Image(
+                modifier = Modifier
+                    .clickable { onFilterClicked() }
+                    .size(width = 48.dp, height = 48.dp)
+                    .padding(12.dp),
+                painter = painterResource(id = R.drawable.ic_filter),
+                contentDescription = "Filter"
+            )
+        }
     }
 }
 

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/component/SwipeToRefreshUI.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/component/SwipeToRefreshUI.kt
@@ -1,15 +1,17 @@
 package ca.bc.gov.bchealth.ui.component
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 
 @Composable
-fun SwipeToRefreshUI(onRefresh: () -> Unit, content: @Composable () -> Unit) {
+fun SwipeToRefreshUI(modifier: Modifier = Modifier, onRefresh: () -> Unit, content: @Composable () -> Unit) {
     val swipeRefreshState = rememberSwipeRefreshState(false)
-    SwipeRefresh(state = swipeRefreshState, onRefresh = {
+    SwipeRefresh(modifier = modifier.fillMaxSize(), state = swipeRefreshState, onRefresh = {
         swipeRefreshState.isRefreshing = false
         onRefresh()
     }, indicator = { state, trigger ->

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordFragment.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
@@ -28,6 +29,7 @@ import ca.bc.gov.bchealth.ui.BaseSecureFragment
 import ca.bc.gov.bchealth.ui.BaseViewModel
 import ca.bc.gov.bchealth.ui.NavigationAction
 import ca.bc.gov.bchealth.ui.custom.MyHealthToolBar
+import ca.bc.gov.bchealth.ui.healthrecord.filter.PatientFilterViewModel
 import ca.bc.gov.bchealth.ui.login.BcscAuthViewModel
 import ca.bc.gov.bchealth.ui.login.LoginStatus
 import ca.bc.gov.bchealth.utils.launchAndRepeatWithLifecycle
@@ -42,6 +44,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class HealthRecordFragment : BaseSecureFragment(null) {
     private val bcscAuthViewModel: BcscAuthViewModel by viewModels()
     private val healthRecordViewModel: HealthRecordViewModel by viewModels()
+    private val filterViewModel: PatientFilterViewModel by activityViewModels()
 
     override fun getBaseViewModel(): BaseViewModel {
         return healthRecordViewModel
@@ -124,7 +127,12 @@ class HealthRecordFragment : BaseSecureFragment(null) {
                             onClick(record)
                         },
                         onSwipeToRefresh = { healthRecordViewModel.executeOneTimeDataFetch() },
-                        onAddNotesClicked = { findNavController().navigate(R.id.addNotesFragment) }
+                        onAddNotesClicked = { findNavController().navigate(R.id.addNotesFragment) },
+                        onFilterClicked = { findNavController().navigate(R.id.filterFragment) },
+                        onFilterCleared = {
+                            filterViewModel.clearFilter()
+                            healthRecordViewModel.showTimeLine(filterViewModel.getFilterString())
+                        }
                     )
                 },
                 contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.background)
@@ -196,7 +204,7 @@ class HealthRecordFragment : BaseSecureFragment(null) {
             if (state == WorkInfo.State.RUNNING) {
                 healthRecordViewModel.showProgressBar()
             } else {
-                healthRecordViewModel.showTimeLine()
+                healthRecordViewModel.showTimeLine(filterViewModel.getFilterString())
             }
         }
     }

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordScreen.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -116,7 +117,8 @@ private fun HealthRecordScreenContent(
 private fun HGTabLayout(
     onTabSelected: (Int) -> Unit
 ) {
-    var tabIndex by remember { mutableStateOf(0) }
+    var tabIndex by rememberSaveable { mutableStateOf(0) }
+    onTabSelected(tabIndex)
     val tabs = listOf("Timeline", "Notes")
     TabRow(
         backgroundColor = MaterialTheme.colors.background,

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordScreen.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/HealthRecordScreen.kt
@@ -1,19 +1,7 @@
 package ca.bc.gov.bchealth.ui.healthrecord
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
-import androidx.compose.material.FloatingActionButton
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
@@ -22,26 +10,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import ca.bc.gov.bchealth.R
 import ca.bc.gov.bchealth.compose.BasePreview
 import ca.bc.gov.bchealth.compose.MyHealthTheme
 import ca.bc.gov.bchealth.compose.blue
 import ca.bc.gov.bchealth.compose.grey
-import ca.bc.gov.bchealth.compose.smallButton
-import ca.bc.gov.bchealth.ui.component.EmptyStateUI
-import ca.bc.gov.bchealth.ui.component.HGLargeButton
 import ca.bc.gov.bchealth.ui.component.HGProgressIndicator
-import ca.bc.gov.bchealth.ui.component.HealthRecordItemUI
-import ca.bc.gov.bchealth.ui.component.SearchBarUI
 import ca.bc.gov.bchealth.ui.component.SwipeToRefreshUI
 
 @Composable
@@ -51,21 +30,45 @@ fun HealthRecordScreen(
     onUnlockMedicationRecords: () -> Unit,
     onClick: (HealthRecordItem) -> Unit,
     onSwipeToRefresh: () -> Unit,
-    onAddNotesClicked: () -> Unit
+    onAddNotesClicked: () -> Unit,
+    onFilterClicked: () -> Unit,
+    onFilterCleared: () -> Unit
 ) {
     val uiState = viewModel.uiState.collectAsState().value
+
     if (uiState.isLoading) {
         HGProgressIndicator(modifier = modifier)
     } else {
+
+        val updatedFilters = uiState.filters.map {
+            when (it) {
+                HealthRecordType.MEDICATION_RECORD.name -> stringResource(R.string.medications)
+                HealthRecordType.COVID_TEST_RECORD.name -> stringResource(R.string.covid_19_test_result)
+                HealthRecordType.LAB_RESULT_RECORD.name -> stringResource(R.string.lab_results)
+                HealthRecordType.IMMUNIZATION_RECORD.name -> stringResource(R.string.immunization)
+                HealthRecordType.HEALTH_VISIT_RECORD.name -> stringResource(R.string.health_visits)
+                HealthRecordType.SPECIAL_AUTHORITY_RECORD.name -> stringResource(R.string.special_authorities)
+                HealthRecordType.HOSPITAL_VISITS_RECORD.name -> stringResource(R.string.hospital_visits)
+                HealthRecordType.CLINICAL_DOCUMENT_RECORD.name -> stringResource(R.string.clinical_documents)
+                HealthRecordType.DIAGNOSTIC_IMAGING.name -> stringResource(R.string.imaging_reports)
+                else -> {
+                    it
+                }
+            }
+        }
+
         HealthRecordScreenContent(
             modifier,
             uiState.requiredProtectiveWordVerification,
             uiState.healthRecords,
+            updatedFilters,
             uiState.notes,
             onUnlockMedicationRecords = onUnlockMedicationRecords,
             onClick = { onClick(it) },
             onSwipeToRefresh = onSwipeToRefresh,
-            onAddNotesClicked = onAddNotesClicked
+            onAddNotesClicked = onAddNotesClicked,
+            onFilterClicked = onFilterClicked,
+            onFilterCleared = onFilterCleared
         )
     }
 }
@@ -75,49 +78,49 @@ private fun HealthRecordScreenContent(
     modifier: Modifier = Modifier,
     requiredProtectiveWordValidation: Boolean,
     healthRecord: List<HealthRecordItem>,
+    filters: List<String>,
     notes: List<String>,
     onUnlockMedicationRecords: () -> Unit,
     onClick: (HealthRecordItem) -> Unit,
     onSwipeToRefresh: () -> Unit,
-    onAddNotesClicked: () -> Unit
+    onAddNotesClicked: () -> Unit,
+    onFilterClicked: () -> Unit,
+    onFilterCleared: () -> Unit
 ) {
-    var tabIndex by remember { mutableStateOf(0) }
+    var tabIndex by rememberSaveable { mutableStateOf(0) }
     Column(modifier = modifier.fillMaxSize()) {
-        HGTabLayout { index ->
+        HGTabLayout(tabIndex) { index ->
             tabIndex = index
         }
-        when (tabIndex) {
-            0 -> {
-                SwipeToRefreshUI(onRefresh = { onSwipeToRefresh() }) {
-                    if (healthRecord.isEmpty()) {
-                        EmptyStateUI(
-                            modifier,
-                            image = R.drawable.ic_no_record,
-                            title = R.string.no_records_found,
-                            description = R.string.refresh
-                        )
-                    } else {
-                        TimeLine(
-                            modifier,
-                            requiredProtectiveWordValidation,
-                            healthRecords = healthRecord,
-                            onUnlockMedicationRecords = onUnlockMedicationRecords,
-                            onClick = { onClick(it) }
-                        )
-                    }
+        SwipeToRefreshUI(onRefresh = { onSwipeToRefresh() }) {
+            when (tabIndex) {
+                0 -> {
+                    TimeLineScreen(
+                        modifier,
+                        healthRecord,
+                        requiredProtectiveWordValidation,
+                        filters,
+                        onClick,
+                        onUnlockMedicationRecords,
+                        onFilterClicked,
+                        onFilterCleared
+                    )
                 }
-            }
 
-            1 -> Notes(modifier, emptyList(), onAddNotesClicked)
+                1 -> NotesScreen(
+                    modifier,
+                    onAddNotesClicked
+                )
+            }
         }
     }
 }
 
 @Composable
 private fun HGTabLayout(
+    tabIndex: Int,
     onTabSelected: (Int) -> Unit
 ) {
-    var tabIndex by rememberSaveable { mutableStateOf(0) }
     onTabSelected(tabIndex)
     val tabs = listOf("Timeline", "Notes")
     TabRow(
@@ -144,122 +147,9 @@ private fun HGTabLayout(
                 },
                 selected = tabIndex == index,
                 onClick = {
-                    tabIndex = index
                     onTabSelected(index)
                 },
             )
-        }
-    }
-}
-
-@Composable
-private fun TimeLine(
-    modifier: Modifier,
-    requiredProtectiveWordValidation: Boolean,
-    healthRecords: List<HealthRecordItem>,
-    onUnlockMedicationRecords: () -> Unit,
-    onClick: (HealthRecordItem) -> Unit
-) {
-
-    Column(modifier = Modifier.fillMaxSize()) {
-
-        SearchBarUI()
-        LazyColumn(
-            modifier
-                .fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-
-            if (requiredProtectiveWordValidation) {
-                item {
-                    HiddenMedicationRecordUI(onUnlockMedicationRecords = { onUnlockMedicationRecords() })
-                }
-            }
-
-            items(healthRecords) { record ->
-                HealthRecordItemUI(
-                    image = record.icon,
-                    title = record.title,
-                    description = record.description,
-                    onClick = { onClick(record) }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun HiddenMedicationRecordUI(onUnlockMedicationRecords: () -> Unit) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth(),
-        shape = MaterialTheme.shapes.medium,
-        elevation = 4.dp,
-    ) {
-
-        Column(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth()
-        ) {
-            Text(
-                text = stringResource(id = R.string.hidden_medication_records),
-                style = MaterialTheme.typography.h3,
-                color = blue,
-                maxLines = 2,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(id = R.string.enter_protective_word_to_access_medication_records),
-                style = MaterialTheme.typography.smallButton,
-                color = grey,
-                fontWeight = FontWeight.Normal,
-                maxLines = 2
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            HGLargeButton(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { onUnlockMedicationRecords() },
-                text = stringResource(id = R.string.unlock_records),
-                leadingIcon = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_lock),
-                        contentDescription = "lock"
-                    )
-                }
-            )
-        }
-    }
-}
-
-@Composable
-private fun Notes(
-    modifier: Modifier = Modifier,
-    notes: List<String> = emptyList(),
-    onAddNotesClicked: () -> Unit = {}
-) {
-    Box(modifier = modifier.fillMaxSize()) {
-
-        FloatingActionButton(
-            onClick = { onAddNotesClicked() },
-            modifier = Modifier
-                .padding(all = 16.dp)
-                .align(alignment = Alignment.BottomEnd)
-        ) {
-            Icon(painterResource(id = R.drawable.ic_add_notes), "AddNote")
-        }
-        if (notes.isEmpty()) {
-            EmptyStateUI(
-                modifier,
-                image = R.drawable.ic_empty_note,
-                title = R.string.notes_empty_title,
-                description = R.string.notes_empty_description
-            )
-        } else {
         }
     }
 }
@@ -271,10 +161,13 @@ private fun HealthRecordScreenPreview() {
         HealthRecordScreenContent(
             requiredProtectiveWordValidation = true,
             healthRecord = emptyList(), notes = emptyList(),
+            filters = emptyList(),
             onUnlockMedicationRecords = {},
             onClick = {},
             onSwipeToRefresh = {},
-            onAddNotesClicked = {}
+            onAddNotesClicked = {},
+            onFilterClicked = {},
+            onFilterCleared = {}
         )
     }
 }

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/NotesScreen.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/NotesScreen.kt
@@ -1,0 +1,69 @@
+package ca.bc.gov.bchealth.ui.healthrecord
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import ca.bc.gov.bchealth.R
+import ca.bc.gov.bchealth.compose.BasePreview
+import ca.bc.gov.bchealth.compose.MyHealthTheme
+import ca.bc.gov.bchealth.ui.component.EmptyStateUI
+import ca.bc.gov.bchealth.ui.component.SearchBarUI
+
+@Composable
+fun NotesScreen(
+    modifier: Modifier = Modifier,
+    onAddNotesClicked: () -> Unit
+) {
+    NotesScreenContent(modifier, onAddNotesClicked)
+}
+
+@Composable
+private fun NotesScreenContent(
+    modifier: Modifier = Modifier,
+    onAddNotesClicked: () -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxSize()
+        ) {
+            SearchBarUI(modifier = Modifier.fillMaxWidth(), enableFilter = false)
+            Spacer(modifier = Modifier.height(16.dp))
+            EmptyStateUI(
+                modifier,
+                image = R.drawable.ic_empty_note,
+                title = R.string.notes_empty_title,
+                description = R.string.notes_empty_description
+            )
+        }
+        FloatingActionButton(
+            onClick = onAddNotesClicked,
+            modifier = Modifier
+                .padding(all = 16.dp)
+                .align(alignment = Alignment.BottomEnd)
+        ) {
+            Icon(painterResource(id = R.drawable.ic_add_notes), "AddNote")
+        }
+    }
+}
+
+@Composable
+@BasePreview
+private fun NotesScreenPreview() {
+    MyHealthTheme {
+        NotesScreenContent()
+    }
+}

--- a/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/TimeLineScreen.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/ui/healthrecord/TimeLineScreen.kt
@@ -1,0 +1,173 @@
+package ca.bc.gov.bchealth.ui.healthrecord
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import ca.bc.gov.bchealth.R
+import ca.bc.gov.bchealth.compose.BasePreview
+import ca.bc.gov.bchealth.compose.MyHealthTheme
+import ca.bc.gov.bchealth.compose.blue
+import ca.bc.gov.bchealth.compose.grey
+import ca.bc.gov.bchealth.compose.smallButton
+import ca.bc.gov.bchealth.ui.component.AppliedFilterUI
+import ca.bc.gov.bchealth.ui.component.EmptyStateUI
+import ca.bc.gov.bchealth.ui.component.HGLargeButton
+import ca.bc.gov.bchealth.ui.component.HealthRecordItemUI
+import ca.bc.gov.bchealth.ui.component.SearchBarUI
+
+@Composable
+fun TimeLineScreen(
+    modifier: Modifier = Modifier,
+    healthRecords: List<HealthRecordItem>,
+    requiredProtectiveWordValidation: Boolean,
+    filtersApplied: List<String>,
+    onClick: (HealthRecordItem) -> Unit,
+    onUnlockMedicationRecords: () -> Unit,
+    onFilterClicked: () -> Unit,
+    onFilterCleared: () -> Unit
+) {
+    TimeLineScreenContent(
+        modifier,
+        healthRecords,
+        requiredProtectiveWordValidation,
+        filtersApplied,
+        onClick = onClick,
+        onUnlockMedicationRecords = onUnlockMedicationRecords,
+        onFilterClicked = onFilterClicked,
+        onFilterCleared = onFilterCleared
+    )
+}
+
+@Composable
+private fun TimeLineScreenContent(
+    modifier: Modifier = Modifier,
+    healthRecords: List<HealthRecordItem> = emptyList(),
+    requiredProtectiveWordValidation: Boolean,
+    filtersApplied: List<String>,
+    onUnlockMedicationRecords: () -> Unit = {},
+    onClick: (HealthRecordItem) -> Unit = {},
+    onFilterClicked: () -> Unit = {},
+    onFilterCleared: () -> Unit = {}
+) {
+
+    Column(
+        modifier = modifier
+            .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+            .fillMaxSize()
+    ) {
+
+        SearchBarUI(modifier = Modifier.fillMaxWidth(), onFilterClicked = onFilterClicked)
+        Spacer(modifier = Modifier.height(16.dp))
+        if (filtersApplied.isNotEmpty()) {
+            AppliedFilterUI(
+                modifier = Modifier.fillMaxWidth(),
+                filtersApplied,
+                onFilterCleared
+            )
+        }
+
+        if (healthRecords.isEmpty()) {
+            EmptyStateUI(
+                modifier,
+                image = R.drawable.ic_no_record,
+                title = R.string.no_records_found,
+                description = R.string.refresh
+            )
+        } else {
+            LazyColumn(
+                modifier
+                    .fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+
+                if (requiredProtectiveWordValidation) {
+                    item {
+                        HiddenMedicationRecordUI(onUnlockMedicationRecords = { onUnlockMedicationRecords() })
+                    }
+                }
+                items(healthRecords) { record ->
+                    HealthRecordItemUI(
+                        image = record.icon,
+                        title = record.title,
+                        description = record.description,
+                        onClick = { onClick(record) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HiddenMedicationRecordUI(onUnlockMedicationRecords: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        elevation = 4.dp,
+    ) {
+
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.hidden_medication_records),
+                style = MaterialTheme.typography.h3,
+                color = blue,
+                maxLines = 2,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(id = R.string.enter_protective_word_to_access_medication_records),
+                style = MaterialTheme.typography.smallButton,
+                color = grey,
+                fontWeight = FontWeight.Normal,
+                maxLines = 2
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            HGLargeButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { onUnlockMedicationRecords() },
+                text = stringResource(id = R.string.unlock_records),
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_lock),
+                        contentDescription = stringResource(id = R.string.unlock_records)
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+@BasePreview
+private fun TimeLineScreenContentPreview() {
+    MyHealthTheme {
+        TimeLineScreenContent(
+            requiredProtectiveWordValidation = false,
+            filtersApplied = emptyList()
+        )
+    }
+}

--- a/app/src/main/java/ca/bc/gov/bchealth/utils/Extensions.kt
+++ b/app/src/main/java/ca/bc/gov/bchealth/utils/Extensions.kt
@@ -223,7 +223,7 @@ fun View.showNoInternetConnectionMessage(context: Context) {
     showErrorSnackbar(context.getString(R.string.no_internet_connection))
 }
 
-fun View?.showErrorSnackbar(message: String) {
+fun View?.showErrorSnackbar(message: String, anchor: View? = null) {
     this ?: return
 
     val snackBar = Snackbar.make(
@@ -232,6 +232,10 @@ fun View?.showErrorSnackbar(message: String) {
     snackBar.setAction(context.getString(R.string.dismiss)) {
         performClick()
     }
+    if (anchor != null) {
+        snackBar.anchorView = anchor
+    }
+
     snackBar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text).maxLines =
         10
     snackBar.show()


### PR DESCRIPTION
This PR contains filter implementation on Health record screen with Jetpack Compose
- added search UI to the notes screen
- add ability to filter the data using the filter option and also able to clear the filter by clicking cross button
- re structured Timeline screen and Notes screen for better code clarity.

Known item:
- Search is not working yet, and will be part of the next PR