### PR TITLE
Fix deep link issue and update app version to 2.3.1

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,14 +73,6 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https"
-                    android:host="www2.gov.bc.ca"
-                    android:path="/gov/content/health/managing-your-health/health-gateway*"/>
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="myhealthbc"/>
             </intent-filter>
         </activity>

--- a/scripts/versions.gradle
+++ b/scripts/versions.gradle
@@ -6,8 +6,8 @@ versions.targetSdkVersion = 35
 versions.compileSdkVersion = 35
 
 //App
-versions.versionName = '2.3.0'
-versions.versionCode = 248
+versions.versionName = '2.3.1'
+versions.versionCode = 249
 versions.localApiVersion = 3
 
 //Tools & Libs


### PR DESCRIPTION
Fix deep link issue and update app version to 2.3.1
- removed un used intent filter causing broken deep link issue on the play store. (New release to play store is required)